### PR TITLE
Fix FFmpeg download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An FFmpeg GUI for Windows
 &nbsp;
 
 ## Overview
-Axiom generates command scripts to be processed by multimedia encoder, [FFmpeg](https://www.ffmpeg.org), and streams analyzer, [FFprobe](https://ffmpeg.org/ffprobe.html).
+Axiom generates command scripts to be processed by the multimedia encoder, [FFmpeg](https://www.ffmpeg.org), and streams analyzer, [FFprobe](https://ffmpeg.org/ffprobe.html).
 
 Convert to `webm`, `mp4`, `mkv`, `avi`, `ogv`, `mp3`, `m4a`, `ogg`, `flac`, `wav`, `png`, `jpg`, `webp` and more.
 
@@ -71,7 +71,7 @@ Axiom is portable and can be run from any location on the computer.
 2. Go to Control Panel → System and Security → System → Advanced system settings
 3. Advanced Tab → Environment Variables → System variables → Path
 4. Add `C:\Program Files\ffmpeg\bin\`
-5. Separate multiple paths with semicolon `;` (Windows 7, 8, 8.1)
+5. Separate multiple paths with a semicolon `;` (Windows 7, 8, 8.1)
 6. Typing `ffmpeg` in Command Prompt will now execute without needing to specify a direct path.
 
 <a href="https://raw.githubusercontent.com/MattMcManis/Axiom/master/docs/Windows%20Environment%20Variables/Environment-Variables.png" target="_blank"><img src="https://raw.githubusercontent.com/MattMcManis/Axiom/master/docs/Windows%20Environment%20Variables/Environment-Variables.png" width="500"/></a> 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ https://github.com/MattMcManis/Axiom/releases
 
 #### Files
 - Axiom UI
-- [FFmpeg](https://ffmpeg.zeranoe.com/builds)
+- [FFmpeg](http://www.ffmpeg.org/download.html#build-windows)
 - [youtube-dl](https://github.com/ytdl-org/youtube-dl/releases)
 - Install Instructions
 - User Guide pdf
@@ -53,7 +53,7 @@ https://github.com/MattMcManis/Axiom/releases
 - youtube-dl [Visual C++ 2010 x86](https://www.microsoft.com/en-US/download/details.aspx?id=5555) & [Python](https://www.python.org) (2.6, 2.7, or 3.2+)
 
 #### FFmpeg Builds
-https://ffmpeg.zeranoe.com/builds
+https://www.gyan.dev/ffmpeg/builds/ or https://github.com/BtbN/FFmpeg-Builds/releases
 
 &nbsp;
 


### PR DESCRIPTION
The old link as "https://ffmpeg.zeranoe.com/builds" is no longer for access and FFmpeg official website change the download link to "https://www.gyan.dev/ffmpeg/builds/ or https://github.com/BtbN/FFmpeg-Builds/releases" instead of the old link. See this at http://www.ffmpeg.org/download.html#build-windows.